### PR TITLE
Remove Deprecation Warning on math division.

### DIFF
--- a/src/_sass/_base.scss
+++ b/src/_sass/_base.scss
@@ -16,7 +16,7 @@ h1, h2, h3, h4, h5, h6,
 p, blockquote, pre,
 ul, ol, dl, figure,
 %vertical-rhythm {
-    margin-bottom: $spacing-unit / 2;
+    margin-bottom: calc($spacing-unit / 2);
 }
 
 /**
@@ -62,8 +62,8 @@ li {
  */
 h1, h2, h3, h4, h5, h6 {
     font-weight: 300;
-    margin-top: ($spacing-unit/2) !important;
-    margin-bottom: ($spacing-unit/4) !important;
+    margin-top: calc($spacing-unit / 2) !important;
+    margin-bottom: calc($spacing-unit / 4) !important;
 }
 
 
@@ -91,7 +91,7 @@ a {
  */
 blockquote {
     border-left: 4px solid lighten($complimentary-color, 35%);
-    padding-left: $spacing-unit / 2;
+    padding-left: calc($spacing-unit / 2);
 
     > :last-child {
         margin-bottom: 0;

--- a/src/_sass/_layout.scss
+++ b/src/_sass/_layout.scss
@@ -26,8 +26,8 @@
 
 .wrap .banner {
     flex: 0 1 auto;
-    padding-top: ($spacing-unit/2);
-    padding-bottom: ($spacing-unit/2);
+    padding-top: calc($spacing-unit / 2);
+    padding-bottom: calc($spacing-unit / 2);
     padding-right: $spacing-unit*2;
     padding-left: $spacing-unit*2;
 }
@@ -40,8 +40,8 @@
 }
 .wrap .row.spacer {
     flex: 0 1 auto;
-    padding-top: ($spacing-unit/2);
-    padding-bottom: ($spacing-unit/2);
+    padding-top: calc($spacing-unit / 2);
+    padding-bottom: calc($spacing-unit / 2);
 }
 .wrap .row.content {
     flex: 1 1 auto;
@@ -50,13 +50,13 @@
 }
 .wrap .footer {
     flex: 0 1 $footer-height;
-    padding-top: ($spacing-unit/4);
-    padding-bottom: ($spacing-unit/4);
+    padding-top: calc($spacing-unit / 4);
+    padding-bottom: calc($spacing-unit / 4);
     padding-right: $spacing-unit*2;
     padding-left: $spacing-unit*2;
 }
 .wrap .blog-navigation {
-    padding-bottom: ($spacing-unit/4);
+    padding-bottom: calc($spacing-unit / 4);
 }
 
 .breadcrumb ul {
@@ -81,7 +81,7 @@
 }
 
 .navigation {
-    padding-top: ($spacing-unit/2);
+    padding-top: calc($spacing-unit / 2);
     padding-bottom: 0;
 }
 
@@ -180,7 +180,7 @@ input[type=submit]:hover {
 
 .search-excerpt {
     font-size: $small-font-size;
-    padding-top: ($spacing-unit/4);
+    padding-top: calc($spacing-unit / 4);
 }
 
 .recent-posts ul {
@@ -254,8 +254,8 @@ html,body {
     content: "";
     display: block;
     color: darken($complimentary-color, 35%);
-    margin-top: $spacing-unit/2;
-    margin-bottom: $spacing-unit/2;
+    margin-top: calc($spacing-unit / 2);
+    margin-bottom: calc($spacing-unit / 2);
     text-align: center;
 }
 

--- a/src/_sass/_navigation.scss
+++ b/src/_sass/_navigation.scss
@@ -23,8 +23,8 @@
 .navbar {
     height: $navbar-height;
     background-color: $navbar-backgroundcolor;
-    padding-left: ($spacing-unit/2);
-    padding-right: ($spacing-unit/2);
+    padding-left: calc($spacing-unit / 2);
+    padding-right: calc($spacing-unit / 2);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -125,16 +125,16 @@
 }
 
 #nav .dropdown {
-    line-height: ($navbar-height/2);
+    line-height: calc($navbar-height / 2);
 }
 
 #nav .dropdown>ul {
-    line-height: ($navbar-height/2);
+    line-height: calc($navbar-height / 2);
     max-height: $navbar-height*12;
 }
 
 #nav .subdropdown>ul {
-    line-height: ($navbar-height/2);
+    line-height: calc($navbar-height / 2);
     max-height: $navbar-height*12;
     overflow-y: auto;
     scrollbar-color: $navbar-active-backgroundcolor $navbar-active-color;
@@ -150,7 +150,7 @@
     width: 0;
     border: 4px solid transparent;
     border-top-color: inherit;
-    right: ($navbar-height / 4);
+    right: calc($navbar-height / 4);
     top: 48%;
 }
 

--- a/src/_sass/_variables.scss
+++ b/src/_sass/_variables.scss
@@ -69,7 +69,7 @@ $breadcrumb-hover-color: $secondary-color;
 $breadcrumb-hover-backgroundcolor: $primary-color;
 $breadcrumb-link-color: $link-color;
 $breadcrumb-spacing: 10px;
-$breadcrumb-half-height: $breadcrumb-height/2;
+$breadcrumb-half-height: calc($breadcrumb-height / 2);
 
 // Blog Navigation
 $blog-navigation-height: 24px;
@@ -78,7 +78,7 @@ $blog-navigation-backgroundcolor: $secondary-color;
 $blog-navigation-hover-color: $secondary-color;
 $blog-navigation-hover-backgroundcolor: $primary-color;
 $blog-navigation-spacing: 15px;
-$blog-navigation-half-height: $blog-navigation-height/2;
+$blog-navigation-half-height: calc($blog-navigation-height / 2);
 
 // Pagination
 $pagination-height: 24px;

--- a/src/_sass/foundation/components/_visibility.scss
+++ b/src/_sass/foundation/components/_visibility.scss
@@ -6,7 +6,7 @@
 /// @param {Keyword} $size - Breakpoint to use. **Must be a breakpoint defined in `$breakpoints`.**
 @mixin show-for($size) {
   $size: map-get($breakpoints, $size);
-  $size: -zf-bp-to-em($size) - (1 / 16);
+  $size: -zf-bp-to-em($size) - calc(1 / 16);
 
   @include breakpoint($size down) {
     display: none !important;
@@ -20,7 +20,7 @@
   $upper-bound-size: -zf-map-next($breakpoints, $size);
 
   // more often than not this will be correct, just one time round the loop it won't so set in scope here
-  $lower-bound: -zf-bp-to-em($lower-bound-size) - (1 / 16);
+  $lower-bound: -zf-bp-to-em($lower-bound-size) - calc(1 / 16);
   // test actual lower-bound-size, if 0 set it to 0em
   @if strip-unit($lower-bound-size) == 0 {
     $lower-bound: -zf-bp-to-em($lower-bound-size);

--- a/src/_sass/foundation/grid/_column.scss
+++ b/src/_sass/foundation/grid/_column.scss
@@ -27,7 +27,7 @@
       $width: percentage($columns);
     }
     @else {
-      $width: percentage($columns / $grid-column-count);
+      $width: percentage(calc($columns / $grid-column-count));
     }
   }
 
@@ -63,7 +63,7 @@
   // Gutters
   @if type-of($gutter) == 'map' {
     @each $breakpoint, $value in $gutter {
-      $padding: rem-calc($value) / 2;
+      $padding: calc(rem-calc($value) / 2);
 
       @include breakpoint($breakpoint) {
         padding-left: $padding;

--- a/src/_sass/foundation/grid/_gutter.scss
+++ b/src/_sass/foundation/grid/_gutter.scss
@@ -16,7 +16,7 @@
 ///
 /// @param {Number} $gutter [$grid-column-gutter] - Spacing between columns.
 @mixin grid-column-uncollapse($gutter: $grid-column-gutter) {
-  $gutter: rem-calc($gutter) / 2;
+  $gutter: calc(rem-calc($gutter) / 2);
   padding-left: $gutter;
   padding-right: $gutter;
 }

--- a/src/_sass/foundation/grid/_layout.scss
+++ b/src/_sass/foundation/grid/_layout.scss
@@ -15,7 +15,7 @@
   $selector: '.column'
 ) {
   & > #{$selector} {
-    width: percentage(1/$n);
+    width: percentage(calc(1/$n));
     float: $global-left;
 
     &:nth-of-type(1n) {

--- a/src/_sass/foundation/grid/_position.scss
+++ b/src/_sass/foundation/grid/_position.scss
@@ -11,7 +11,7 @@
 /// @param {Number} $position - Direction and amount to move. The column will move equal to the width of the column count specified. A positive number will push the column to the right, while a negative number will pull it to the left.
 @mixin grid-column-position($position) {
   @if type-of($position) == 'number' {
-    $offset: percentage($position / $grid-column-count);
+    $offset: percentage(calc($position / $grid-column-count));
 
     position: relative;
     #{$global-left}: $offset;

--- a/src/_sass/foundation/grid/_row.scss
+++ b/src/_sass/foundation/grid/_row.scss
@@ -84,7 +84,7 @@
   }
 
   @each $breakpoint, $value in $gutter {
-    $margin: rem-calc($value) / 2 * -1;
+    $margin: calc(rem-calc($value) / 2 * -1);
 
     @include breakpoint($breakpoint) {
       margin-left: $margin;

--- a/src/_sass/foundation/util/_breakpoint.scss
+++ b/src/_sass/foundation/util/_breakpoint.scss
@@ -72,7 +72,7 @@ $breakpoint-classes: (small medium large) !default;
   // Convert any pixel, rem, or unitless value to em
   $bp: -zf-bp-to-em($bp);
   @if $bp-max {
-    $bp-max: -zf-bp-to-em($bp-max) - (1/16);
+    $bp-max: -zf-bp-to-em($bp-max) - calc(1/16);
   }
 
   // Conditions to skip media query creation

--- a/src/_sass/foundation/util/_unit.scss
+++ b/src/_sass/foundation/util/_unit.scss
@@ -6,6 +6,8 @@
 /// @group functions
 ////
 
+@use 'sass:math';
+
 $global-font-size: 100% !default;
 
 // scss-lint:disable ZeroUnit
@@ -16,7 +18,7 @@ $global-font-size: 100% !default;
 ///
 /// @returns {Number} The same number, sans unit.
 @function strip-unit($num) {
-  @return $num / ($num * 0 + 1);
+  @return math.div($num, $num * 0 + 1);
 }
 
 /// Converts one or more pixel values into matching rem values.
@@ -37,7 +39,7 @@ $global-font-size: 100% !default;
   // If the base font size is a %, then multiply it by 16px
   // This is because 100% font size = 16px in most all browsers
   @if unit($base) == '%' {
-    $base: ($base / 100%) * 16px;
+    $base: calc($base / 100%) * 16px;
   }
 
   @if $count == 1 {
@@ -78,7 +80,7 @@ $global-font-size: 100% !default;
 
   // Calculate rem if units for $value is not rem
   @if unit($value) != 'rem' {
-    $value: strip-unit($value) / strip-unit($base) * 1rem;
+    $value: calc(strip-unit($value) / strip-unit($base) * 1rem);
   }
 
   // Turn 0rem into 0


### PR DESCRIPTION
Using '/' for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0. All ocurrences were fixed by using calc(), except in 'strip-units', where math.div was used.