### PR TITLE
Add 'raw' tag to YAML snippets

### DIFF
--- a/src/documentation/plugins/idrange.md
+++ b/src/documentation/plugins/idrange.md
@@ -131,6 +131,7 @@ Example playbook to ensure an AD-trust idrange is present, with range type 'trus
 
 Example playbook to ensure an AD-trust idrange has auto creation of groups set to 'hybrid':
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage IPA idrange.
@@ -145,6 +146,7 @@ Example playbook to ensure an AD-trust idrange has auto creation of groups set t
       name: ad_id_range
       auto_private_groups: "hybrid"
 ```
+{% endraw %}
 
 Example playbook to make sure an idrange is absent:
 

--- a/src/documentation/plugins/topology.md
+++ b/src/documentation/plugins/topology.md
@@ -121,6 +121,7 @@ Example playbook to verify a topology suffix:
 
 Example playbook to add or remove or check or reinitialize a list of topology segments:
 
+{% raw %}
 ```yaml
 ---
 - name: Add topology segments
@@ -150,6 +151,7 @@ Example playbook to add or remove or check or reinitialize a list of topology se
       #state: reinitialized
     loop: "{{ ipatopology_segments | default([]) }}"
 ```
+{% endraw %}
 
 
 Variables


### PR DESCRIPTION
Documentation for idrange and topology plugins include the pipe ('|') character, which requires the usage of the 'raw' tag for proper rendering using Jekill.

Both documents were fixed, by wrapping the offending YAML snippets with "{% raw %}/{% endraw %}"