### PR TITLE
src/_includes/header.html: Add site.baseurl for the banner image

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -1,3 +1,3 @@
 <header class="banner">
-  <a class="page-banner" href="{{ site.baseurl }}/"><img class="banner-image" src="/images/ansible-freeipa2_300x60.png"></a><br>
+  <a class="page-banner" href="{{ site.baseurl }}/"><img class="banner-image" src="{{ site.baseurl }}/images/ansible-freeipa2_300x60.png"></a><br>
 </header>


### PR DESCRIPTION
The banner image src was missing the site.baseurl, therefore the image was not found. It should have been
https://freeipa.github.io/ansible-freeipa.github.io/images/ but instead https://freeipa.github.io/images/ was used.