### PR TITLE
Allow selecting documents using tags

### DIFF
--- a/src/_includes/asides/tags.html
+++ b/src/_includes/asides/tags.html
@@ -1,0 +1,19 @@
+<aside class="small-12 recent-posts">
+  <h2>Tags</h2>
+  <ul id="tag-list">
+    <!-- sort tags by name -->
+    {% capture site_tags %}
+        {% for tag in site.tags %}
+            {{ tag | first }}{% unless forloop.last %},{% endunless %}
+        {% endfor %}
+    {% endcapture %}
+    {% assign list_of_tags = site_tags | split:',' | sort_natural %}
+
+    <!-- list tags -->
+    {% for tag in list_of_tags -%}
+    <li>
+      <a href="{{ site.baseurl }}/tags#{{ tag | strip }}">{{ tag | strip }}</a>
+    </li>
+    {% endfor -%}
+  </ul>
+</aside>

--- a/src/_layouts/home.html
+++ b/src/_layouts/home.html
@@ -16,6 +16,7 @@
 {%  include asides/search.html -%}
 {%  include asides/recent_posts.html -%}
 {%  include asides/quick_links.html -%}
+{%  include asides/tags.html -%}
         </section>
       </article>
     </div>

--- a/src/_layouts/page.html
+++ b/src/_layouts/page.html
@@ -12,6 +12,7 @@ layout: default
 {%  include asides/search.html -%}
 {%  include asides/recent_posts.html -%}
 {%  include asides/quick_links.html -%}
+{%  include asides/tags.html -%}
     </section>
   </article>
 </div>

--- a/src/_layouts/post.html
+++ b/src/_layouts/post.html
@@ -28,6 +28,7 @@
       {% include asides/search.html -%}
       {% include asides/recent_posts.html -%}
       {% include asides/quick_links.html -%}
+      {% include asides/tags.html -%}
     </section>
   </article>
 

--- a/src/_sass/_base.scss
+++ b/src/_sass/_base.scss
@@ -156,3 +156,13 @@ pre {
         }
     }
 }
+
+ul#tag-list {
+  li {
+    ::before {
+       content: '#';
+    }
+    display: inline-block;
+    margin-right: 1ch;
+  }
+}

--- a/src/blog/_posts/2021-12-02-ansible-freeipa-1.5.0.md
+++ b/src/blog/_posts/2021-12-02-ansible-freeipa-1.5.0.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2021-12-02T13:48:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlights in version 1.5.0

--- a/src/blog/_posts/2021-12-15-ansible-freeipa-1.5.1.md
+++ b/src/blog/_posts/2021-12-15-ansible-freeipa-1.5.1.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2021-12-15T09:02:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlights in version 1.5.1

--- a/src/blog/_posts/2021-12-23-ansible-freeipa-1.5.2.md
+++ b/src/blog/_posts/2021-12-23-ansible-freeipa-1.5.2.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2021-12-23T14:21:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Changes since 1.5.1

--- a/src/blog/_posts/2021-12-28-ansible-freeipa-1.5.3.md
+++ b/src/blog/_posts/2021-12-28-ansible-freeipa-1.5.3.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2021-12-28T15:26:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Changes since 1.5.2

--- a/src/blog/_posts/2022-01-17-ansible-freeipa-1.7.0.md
+++ b/src/blog/_posts/2022-01-17-ansible-freeipa-1.7.0.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2022-01-17T09:39:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlights in version 1.6.0

--- a/src/blog/_posts/2022-01-21-ansible-freeipa-1.6.1.md
+++ b/src/blog/_posts/2022-01-21-ansible-freeipa-1.6.1.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2022-01-21T16:39:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlights in version 1.6.1

--- a/src/blog/_posts/2022-01-26-ansible-freeipa-1.6.2.md
+++ b/src/blog/_posts/2022-01-26-ansible-freeipa-1.6.2.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2022-01-26T15:22:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Changes since 1.6.1

--- a/src/blog/_posts/2022-01-27-ansible-freeipa-1.6.3.md
+++ b/src/blog/_posts/2022-01-27-ansible-freeipa-1.6.3.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2022-01-27T15:48:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Changes since 1.6.2

--- a/src/blog/_posts/2022-04-29-ansible-freeipa-1.7.0.md
+++ b/src/blog/_posts/2022-04-29-ansible-freeipa-1.7.0.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2022-04-29T15:16:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlights in version 1.7.0

--- a/src/blog/_posts/2022-06-24-ansible-freeipa-1.8.0.md
+++ b/src/blog/_posts/2022-06-24-ansible-freeipa-1.8.0.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2022-06-24T14:19:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlights in version 1.8.0

--- a/src/blog/_posts/2022-07-07-ansible-freeipa-1.8.1.md
+++ b/src/blog/_posts/2022-07-07-ansible-freeipa-1.8.1.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2022-07-07T10:57:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlights in version 1.8.1

--- a/src/blog/_posts/2022-07-28-ansible-freeipa-1.8.2.md
+++ b/src/blog/_posts/2022-07-28-ansible-freeipa-1.8.2.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2022-07-28T14:38:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlights in version 1.8.2

--- a/src/blog/_posts/2022-08-16-ansible-freeipa-1.8.3.md
+++ b/src/blog/_posts/2022-08-16-ansible-freeipa-1.8.3.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2022-08-16T14:43:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlight in version 1.8.3

--- a/src/blog/_posts/2022-09-09-ansible-freeipa-1.8.4.md
+++ b/src/blog/_posts/2022-09-09-ansible-freeipa-1.8.4.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2022-09-09T08:05:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlights in 1.8.4

--- a/src/blog/_posts/2022-12-05-ansible-freeipa-1.9.0.md
+++ b/src/blog/_posts/2022-12-05-ansible-freeipa-1.9.0.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2022-12-05T04:21:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlights in 1.9.0

--- a/src/blog/_posts/2023-01-30-ansible-freeipa-1.9.1.md
+++ b/src/blog/_posts/2023-01-30-ansible-freeipa-1.9.1.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2023-01-30T03:54:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlights in 1.9.1

--- a/src/blog/_posts/2023-01-31-ansible-freeipa-1.9.2.md
+++ b/src/blog/_posts/2023-01-31-ansible-freeipa-1.9.2.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2023-01-31T03:35:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Changes since 1.9.1

--- a/src/blog/_posts/2023-04-05-ansible-freeipa-1.10.0.md
+++ b/src/blog/_posts/2023-04-05-ansible-freeipa-1.10.0.md
@@ -5,6 +5,8 @@ section: Blog
 date: 2023-04-05T04:30:00
 author: Thomas Woerner
 category: release
+tags:
+  - release
 ---
 
 Highlights in 1.10.0

--- a/src/tags.md
+++ b/src/tags.md
@@ -1,0 +1,25 @@
+---
+layout: home
+title: Tags
+---
+
+# {{ page.title }}
+
+<!-- sort tags by name -->
+{% capture site_tags %} 
+{% for tag in site.tags %}
+    {{ tag | first }}{% unless forloop.last %},{% endunless %}
+{% endfor %}
+{% endcapture %}
+{% assign tags_list = site_tags | split:',' | sort_natural %}
+
+<!-- List all tags with links to docs -->
+{% for tag in tags_list %}
+{% assign tag_name = tag | strip %}
+# {{ tag_name }}
+{% assign posts = site.tags[tag_name] %}
+{% for post in posts %}* [{{ post.title }}]({{ post.url }})
+{% endfor %}
+
+{% endfor %}
+


### PR DESCRIPTION
Tags can be viewed as keywords an can be used to aid on selecting documents which might be related.

This change adds a list of all tags available in ansible-freeipa documentation after the 'Quick Links' section, and a new page 'tags' containing a list of tags with links to all documents that contain the tag.

Tag lists are sorted.