### PR TITLE
utils: Add script to run Jekyll locally on a container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ _site/
 src/.jekyll-cache/
 vendor/
 
+# Container data
+.vendor/
+
 # temporary files
 *~
 *.swp

--- a/utils/Dockerfile
+++ b/utils/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:alpine
+
+RUN apk add --no-cache make gcc g++ libc-dev openssl-dev
+
+VOLUME ["/srv/jekyll"]
+
+EXPOSE 4000
+
+ENV GEM_HOME="/usr/local/bundle"
+ENV BUNDLE_PATH=/usr/local/bundle BUNDLE_SILENCE_ROOT_WARNING=1 BUNDLE_APP_CONFIG=/usr/local/bundle
+ENV PATH=/usr/local/bundle/bin:/usr/local/bundle/gems/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN mkdir -p "/usr/local/bundle"
+
+WORKDIR "/srv/jekyll"
+ENTRYPOINT ["/bin/sh", "-c", "bundle install && bundle exec jekyll server --trace --host 0.0.0.0"]

--- a/utils/local_server.sh
+++ b/utils/local_server.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+
+if [ "$1" == "-h" ]
+then
+    echo -e "usage: local_serve.sh [-r] [-h]\n"
+    cat <<EOM
+      -h        Display this help message and exit.
+      -r        Force container rebuild.
+EOM
+    exit 0
+fi
+
+SCRIPTDIR="$(realpath $(dirname $0))"
+TOPDIR="$(dirname ${SCRIPTDIR})"
+
+TAG="$(whoami)/ansible-freeipa_docs"
+
+[ -d "${TOPDIR}/.vendor/bundle" ] || mkdir -p "${TOPDIR}/.vendor/bundle"
+
+echo -n "Searching image... "
+existing=$(podman images -f reference="localhost/${TAG}" --format "{{ .Repository }}")
+echo "${existing:-NO}"
+
+echo "Building image..."
+[ "$1" == "-r" ] || [ -z "${existing}" ] && podman build -t "${TAG}" "${SCRIPTDIR}"
+
+echo "Running container..."
+podman run \
+    --volume "${TOPDIR}:/srv/jekyll:Z" \
+    --volume "${TOPDIR}/vendor/bundle:/usr/local/bundle:Z" \
+    -p 4000:4000 \
+    "${TAG}"
+


### PR DESCRIPTION
This patch add a new script 'utils/local_server.sh' that prepares and launch a container running Jekyll, to test documentation locally. The script uses 'podman' to build and run the container image.