### PR TITLE
Fix Liquid syntax errors due to embedded yaml and ini data

### DIFF
--- a/src/documentation/plugins/idoverrideuser.md
+++ b/src/documentation/plugins/idoverrideuser.md
@@ -42,14 +42,17 @@ Usage
 
 Example inventory file
 
+{% raw %}
 ```ini
 [ipaserver]
 ipaserver.test.local
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -63,10 +66,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       idview: test_idview
       anchor: test_user
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview with description
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -81,10 +86,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       description: "test_user description"
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview without description
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -99,10 +106,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       description: ""
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview with internal name test_123_user
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -117,10 +126,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       name: test_123_user
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview without internal name
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -135,10 +146,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       name: ""
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview with uid 20001
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -153,10 +166,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       uid: 20001
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview without uid
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -171,10 +186,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       uid: ""
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview with gecos "Gecos Test"
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -189,10 +206,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       gecos: Gecos Test
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview without gecos
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -207,10 +226,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       gecos: ""
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview with gidnumber
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -225,10 +246,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       gidnumber: 20001
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview without gidnumber
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -243,10 +266,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       gidnumber: ""
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview with homedir /Users
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -261,10 +286,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       homedir: /Users
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview without homedir
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -279,10 +306,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       homedir: ""
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview with shell
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -297,10 +326,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       shell: /bin/someshell
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview without shell
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -315,10 +346,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       shell: ""
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview with sshpubkey
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -334,10 +367,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       sshpubkey:
       - ssh-rsa AAAAB3NzaC1yc2EAAADAQABAAABgQCqmVDpEX5gnSjKuv97Ay ...
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview without sshpubkey
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -352,10 +387,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       sshpubkey: []
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview with 1 certificate
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -371,10 +408,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       certificate:
       - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview with 3 certificate members
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -393,10 +432,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview without 2 certificate members
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -415,10 +456,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       action: member
       state: absent
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview without certificates
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -433,10 +476,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       certificate: []
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is present in idview test_idview with enabling falling back to AD DC LDAP when resolving AD trusted objects. (For two-way trusts only.)
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -451,10 +496,12 @@ Example playbook to make sure test user test_user is present in idview test_idvi
       anchor: test_user
       fallback_to_ldap: true
 ```
+{% endraw %}
 
 
 Example playbook to make sure test user test_user is absent in idview test_idview
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage idoverrideuser
@@ -470,6 +517,7 @@ Example playbook to make sure test user test_user is absent in idview test_idvie
       continue: true
       state: absent
 ```
+{% endraw %}
 
 
 Variables

--- a/src/documentation/plugins/idrange.md
+++ b/src/documentation/plugins/idrange.md
@@ -50,13 +50,16 @@ Usage
 
 Example inventory file
 
+{% raw %}
 ```ini
 [ipaserver]
 ipaserver.test.local
 ```
+{% endraw %}
 
 Example playbook to ensure a local domain idrange is present:
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage IPA idrange.
@@ -71,9 +74,11 @@ Example playbook to ensure a local domain idrange is present:
       base_id: 150000
       range_size: 200000
 ```
+{% endraw %}
 
 Example playbook to ensure a local domain idrange is present, with RID and secondary RID base values:
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage IPA idrange.
@@ -90,9 +95,11 @@ Example playbook to ensure a local domain idrange is present, with RID and secon
       rid_base: 1000000
       secondary_rid_base: 200000000
 ```
+{% endraw %}
 
 Example playbook to ensure an AD-trust idrange is present, with range type 'trust-ad' and using domain SID:
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage IPA idrange.
@@ -109,9 +116,11 @@ Example playbook to ensure an AD-trust idrange is present, with range type 'trus
       idrange_type: ipa-ad-trust
       dom_sid: S-1-5-21-2870384104-3340008087-3140804251
 ```
+{% endraw %}
 
 Example playbook to ensure an AD-trust idrange is present, with range type 'trust-ad-posix' and using domain SID:
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage IPA idrange.
@@ -127,9 +136,11 @@ Example playbook to ensure an AD-trust idrange is present, with range type 'trus
       idrange_type: ipa-ad-trust-posix
       dom_name: ad.ipa.test
 ```
+{% endraw %}
 
 Example playbook to ensure an AD-trust idrange has auto creation of groups set to 'hybrid':
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage IPA idrange.
@@ -144,9 +155,11 @@ Example playbook to ensure an AD-trust idrange has auto creation of groups set t
       name: ad_id_range
       auto_private_groups: "hybrid"
 ```
+{% endraw %}
 
 Example playbook to make sure an idrange is absent:
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to manage IPA idrange.
@@ -160,6 +173,7 @@ Example playbook to make sure an idrange is absent:
       name: ad_id_range
       state: absent
 ```
+{% endraw %}
 
 
 Variables

--- a/src/documentation/plugins/topology.md
+++ b/src/documentation/plugins/topology.md
@@ -35,14 +35,17 @@ Usage
 
 Example inventory file
 
+{% raw %}
 ```ini
 [ipaserver]
 ipaserver.test.local
 ```
+{% endraw %}
 
 
 Example playbook to add a topology segment with default name (cn):
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to handle topologysegment
@@ -58,11 +61,13 @@ Example playbook to add a topology segment with default name (cn):
       right: ipareplica2.test.local
       state: present
 ```
+{% endraw %}
 The name (cn) can also be set if it should not be the default `{left}-to-{right}`.
 
 
 Example playbook to delete a topology segment:
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to handle topologysegment
@@ -78,11 +83,13 @@ Example playbook to delete a topology segment:
       right: ipareplica2.test.local
       state: absent
 ```
+{% endraw %}
 It is possible to either use the name (cn) or left and right nodes. If left and right nodes are used, then the name will be searched and used internally.
 
 
 Example playbook to reinitialize a topology segment:
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to handle topologysegment
@@ -99,11 +106,13 @@ Example playbook to reinitialize a topology segment:
       direction: left-to-right
       state: reinitialized
 ```
+{% endraw %}
 It is possible to either use the name (cn) or left and right nodes. If left and right nodes are used, then the name will be searched and used internally.
 
 
 Example playbook to verify a topology suffix:
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to handle topologysuffix
@@ -117,9 +126,11 @@ Example playbook to verify a topology suffix:
       suffix: domain
       state: verified
 ```
+{% endraw %}
 
 Example playbook to add or remove or check or reinitialize a list of topology segments:
 
+{% raw %}
 ```yaml
 ---
 - name: Add topology segments
@@ -149,6 +160,7 @@ Example playbook to add or remove or check or reinitialize a list of topology se
       #state: reinitialized
     loop: "{{ ipatopology_segments | default([]) }}"
 ```
+{% endraw %}
 
 
 Variables

--- a/src/documentation/roles/server.md
+++ b/src/documentation/roles/server.md
@@ -56,6 +56,7 @@ Usage
 
 Example inventory file with fixed domain and realm, setting up of the DNS server and using forwarders from /etc/resolv.conf:
 
+{% raw %}
 ```ini
 [ipaserver]
 ipaserver2.example.com
@@ -66,9 +67,11 @@ ipaserver_realm=EXAMPLE.COM
 ipaserver_setup_dns=yes
 ipaserver_auto_forwarders=yes
 ```
+{% endraw %}
 
 Example playbook to setup the IPA server using admin and dirman passwords from an [Ansible Vault](http://docs.ansible.com/ansible/latest/playbooks_vault.html) file:
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to configure IPA server
@@ -81,9 +84,11 @@ Example playbook to setup the IPA server using admin and dirman passwords from a
   - role: ipaserver
     state: present
 ```
+{% endraw %}
 
 Example playbook to unconfigure the IPA server using principal and password from inventory file:
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to unconfigure IPA server
@@ -94,9 +99,11 @@ Example playbook to unconfigure the IPA server using principal and password from
   - role: ipaserver
     state: absent
 ```
+{% endraw %}
 
 Example inventory file with fixed domain, realm, admin and dirman passwords:
 
+{% raw %}
 ```ini
 [ipaserver]
 ipaserver.example.com
@@ -107,9 +114,11 @@ ipaserver_realm=EXAMPLE.COM
 ipaadmin_password=MySecretPassword123
 ipadm_password=MySecretPassword234
 ```
+{% endraw %}
 
 Example playbook to setup the IPA server using admin and dirman passwords from inventory file:
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to configure IPA server
@@ -120,11 +129,13 @@ Example playbook to setup the IPA server using admin and dirman passwords from i
   - role: ipaserver
     state: present
 ```
+{% endraw %}
 
 Example playbook to setup the IPA primary with external signed CA using the previous inventory file:
 
 Server installation step 1: Generate CSR, copy to controller as `<ipaserver hostname>-ipa.csr`
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to configure IPA server step1
@@ -144,11 +155,13 @@ Server installation step 1: Generate CSR, copy to controller as `<ipaserver host
       dest: "{{ groups.ipaserver[0] + '-ipa.csr' }}"
       flat: yes
 ```
+{% endraw %}
 
 Sign with CA: This is up to you
 
 Server installation step 2: Copy `<ipaserver hostname>-chain.crt` to the IPA server and continue with installation of the primary.
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to configure IPA server step3
@@ -168,11 +181,13 @@ Server installation step 2: Copy `<ipaserver hostname>-chain.crt` to the IPA ser
   - role: ipaserver
     state: present
 ```
+{% endraw %}
 
 The files can also be copied automatically: Set `ipaserver_copy_csr_to_controller` to true in the server installation step 1 and set `ipaserver_external_cert_files_from_controller` to point to the `chain.crt` file in the server installation step 2.
 
 Since version 4.10, FreeIPA supports creating certificates using random serial numbers. Random serial numbers is a global and permanent setting, that can only be activated while deploying the first server of the domain. Replicas will inherit this setting automatically. An example of an inventory file to deploy a server with random serial numbers enabled is:
 
+{% raw %}
 ```ini
 [ipaserver]
 ipaserver.example.com
@@ -184,12 +199,14 @@ ipaadmin_password=MySecretPassword123
 ipadm_password=MySecretPassword234
 ipaserver_random_serial_numbers=true
 ```
+{% endraw %}
 
 By setting the variable in the inventory file, the same ipaserver deployment playbook, shown before, can be used.
 
 
 Example inventory file to remove a server from the domain:
 
+{% raw %}
 ```ini
 [ipaserver]
 ipaserver.example.com
@@ -198,9 +215,11 @@ ipaserver.example.com
 ipaadmin_password=MySecretPassword123
 ipaserver_remove_from_domain=true
 ```
+{% endraw %}
 
 Example playbook to remove an IPA server using admin passwords from the domain:
 
+{% raw %}
 ```yaml
 ---
 - name: Playbook to remove IPA server
@@ -211,21 +230,26 @@ Example playbook to remove an IPA server using admin passwords from the domain:
   - role: ipaserver
     state: absent
 ```
+{% endraw %}
 
 The inventory will enable the removal of the server (also a replica) from the domain. Additional options are needed if the removal of the server/replica is resulting in a topology disconnect or if the server/replica is the last that has a role.
 
 To continue with the removal with a topology disconnect it is needed to set these parameters:
 
+{% raw %}
 ```ini
 ipaserver_ignore_topology_disconnect=true
 ipaserver_remove_on_server=ipaserver2.example.com
 ```
+{% endraw %}
 
 To continue with the removal for a server that is the last that has a role:
 
+{% raw %}
 ```ini
 ipaserver_ignore_last_of_role=true
 ```
+{% endraw %}
 
 Be careful with enabling the `ipaserver_ignore_topology_disconnect` and especially `ipaserver_ignore_last_of_role`, the change can not be reverted easily.
 


### PR DESCRIPTION
When generating posts with Jekyll, some files generate a Liquid Warning as there are Jinja2 snippets inside some yaml blocks. Yaml, ini and any other language code block should be wrapped inside '{% raw %}/{% endraw %}' tags.

This patche fixes all, but only, files that were trigerring build warnings.